### PR TITLE
Update Templates and Tests for Loose URL Validation Support

### DIFF
--- a/Whois.Tests/Parsing/whois.biz/biz/BizParsingTests.cs
+++ b/Whois.Tests/Parsing/whois.biz/biz/BizParsingTests.cs
@@ -51,6 +51,7 @@ namespace Whois.Parsing.Whois.Biz.Biz
             Assert.AreEqual("292", response.Registrar.IanaId);
             Assert.AreEqual("abusecomplaints@markmonitor.com", response.Registrar.AbuseEmail);
             Assert.AreEqual("+1.2083895740", response.Registrar.AbuseTelephoneNumber);
+            Assert.AreEqual("www.markmonitor.com", response.Registrar.Url);
 
             Assert.AreEqual(new DateTime(2017, 02, 22, 10, 27, 42, 000, DateTimeKind.Utc), response.Updated);
             Assert.AreEqual(new DateTime(2002, 03, 27, 16, 03, 44, 000, DateTimeKind.Utc), response.Registered);
@@ -121,7 +122,7 @@ namespace Whois.Parsing.Whois.Biz.Biz
             Assert.AreEqual("clientUpdateProhibited", response.DomainStatus[2]);
 
             Assert.AreEqual("unsigned", response.DnsSecStatus);
-            Assert.AreEqual(51, response.FieldsParsed);
+            Assert.AreEqual(52, response.FieldsParsed);
         }
     }
 }

--- a/Whois.Tests/Parsing/whois.centralnic.com/eu.com/EuComParsingTests.cs
+++ b/Whois.Tests/Parsing/whois.centralnic.com/eu.com/EuComParsingTests.cs
@@ -50,6 +50,7 @@ namespace Whois.Parsing.Whois.Centralnic.Com.EuCom
             // Registrar Details
             Assert.AreEqual("iTransact Ltd", response.Registrar.Name);
             Assert.AreEqual("01223 700322", response.Registrar.AbuseTelephoneNumber);
+            Assert.AreEqual("www.itransact.ltd.uk", response.Registrar.Url);
 
             Assert.AreEqual(new DateTime(2013, 8, 15, 11, 25, 43, DateTimeKind.Utc), response.Updated);
             Assert.AreEqual(new DateTime(2001, 8, 14, 10, 14, 41, DateTimeKind.Utc), response.Registered);
@@ -114,7 +115,7 @@ namespace Whois.Parsing.Whois.Centralnic.Com.EuCom
             Assert.AreEqual("ok", response.DomainStatus[0]);
 
             Assert.AreEqual("Unsigned", response.DnsSecStatus);
-            Assert.AreEqual(40, response.FieldsParsed);
+            Assert.AreEqual(41, response.FieldsParsed);
         }
     }
 }

--- a/Whois.Tests/Parsing/whois.centralnic.com/gb.com/GbComParsingTests.cs
+++ b/Whois.Tests/Parsing/whois.centralnic.com/gb.com/GbComParsingTests.cs
@@ -49,6 +49,7 @@ namespace Whois.Parsing.Whois.Centralnic.Com.GbCom
             // Registrar Details
             Assert.AreEqual("Wind Internethaus GMBH", response.Registrar.Name);
             Assert.AreEqual("+49.77214070740", response.Registrar.AbuseTelephoneNumber);
+            Assert.AreEqual("www.windinternethaus.de", response.Registrar.Url);
 
             Assert.AreEqual(new DateTime(2014, 2, 12, 9, 45, 17, DateTimeKind.Utc), response.Updated);
             Assert.AreEqual(new DateTime(2006, 4, 23, 6, 26, 11, DateTimeKind.Utc), response.Registered);
@@ -132,7 +133,7 @@ namespace Whois.Parsing.Whois.Centralnic.Com.GbCom
             Assert.AreEqual("serverTransferProhibited", response.DomainStatus[0]);
 
             Assert.AreEqual("Unsigned", response.DnsSecStatus);
-            Assert.AreEqual(52, response.FieldsParsed);
+            Assert.AreEqual(53, response.FieldsParsed);
         }
     }
 }

--- a/Whois.Tests/Parsing/whois.centralnic.com/se.net/SeNetParsingTests.cs
+++ b/Whois.Tests/Parsing/whois.centralnic.com/se.net/SeNetParsingTests.cs
@@ -51,6 +51,7 @@ namespace Whois.Parsing.Whois.Centralnic.Com.SeNet
             Assert.AreEqual("Soluciones Corporativas IP, S.L.U.", response.Registrar.Name);
             Assert.AreEqual("1383", response.Registrar.IanaId);
             Assert.AreEqual("+34.871986600", response.Registrar.AbuseTelephoneNumber);
+            Assert.AreEqual("www.scip.es", response.Registrar.Url);
 
             Assert.AreEqual(new DateTime(2013, 11, 28, 11, 49, 39, DateTimeKind.Utc), response.Updated);
             Assert.AreEqual(new DateTime(2013, 11, 13, 10, 35, 3, DateTimeKind.Utc), response.Registered);
@@ -130,7 +131,7 @@ namespace Whois.Parsing.Whois.Centralnic.Com.SeNet
             Assert.AreEqual("ok", response.DomainStatus[0]);
 
             Assert.AreEqual("Unsigned", response.DnsSecStatus);
-            Assert.AreEqual(53, response.FieldsParsed);
+            Assert.AreEqual(54, response.FieldsParsed);
         }
     }
 }

--- a/Whois.Tests/Parsing/whois.dns.be/be/BeParsingTests.cs
+++ b/Whois.Tests/Parsing/whois.dns.be/be/BeParsingTests.cs
@@ -33,6 +33,7 @@ namespace Whois.Parsing.Whois.Dns.Be.Be
 
             // Registrar Details
             Assert.AreEqual("Register NV/SA", response.Registrar.Name);
+            Assert.AreEqual("www.register.be", response.Registrar.Url);
 
             Assert.AreEqual(new DateTime(2000, 12, 12, 0, 0, 0), response.Registered);
 
@@ -47,7 +48,7 @@ namespace Whois.Parsing.Whois.Dns.Be.Be
             Assert.AreEqual(1, response.DomainStatus.Count);
             Assert.AreEqual("NOT AVAILABLE", response.DomainStatus[0]);
 
-            Assert.AreEqual(10, response.FieldsParsed);
+            Assert.AreEqual(11, response.FieldsParsed);
         }
 
         [Test]
@@ -100,6 +101,7 @@ namespace Whois.Parsing.Whois.Dns.Be.Be
 
             // Registrar Details
             Assert.AreEqual("AXC", response.Registrar.Name);
+            Assert.AreEqual("axc.nl/", response.Registrar.Url);
 
             Assert.AreEqual(new DateTime(2011, 2, 15, 0, 0, 0), response.Registered);
 
@@ -120,7 +122,7 @@ namespace Whois.Parsing.Whois.Dns.Be.Be
             Assert.AreEqual(1, response.DomainStatus.Count);
             Assert.AreEqual("NOT AVAILABLE", response.DomainStatus[0]);
 
-            Assert.AreEqual(12, response.FieldsParsed);
+            Assert.AreEqual(13, response.FieldsParsed);
         }
 
         [Test]
@@ -138,6 +140,9 @@ namespace Whois.Parsing.Whois.Dns.Be.Be
             Assert.AreEqual("ee", response.DomainName.ToString());
 
             Assert.AreEqual(new DateTime(2000, 12, 14, 0, 0, 0), response.Registered);
+
+            // Registrar
+            Assert.AreEqual("www.dns.be", response.Registrar.Url);
 
              // TechnicalContact Details
             Assert.AreEqual("DNS BE Tech", response.TechnicalContact.Name);
@@ -159,7 +164,7 @@ namespace Whois.Parsing.Whois.Dns.Be.Be
             Assert.AreEqual(1, response.DomainStatus.Count);
             Assert.AreEqual("OUT OF SERVICE", response.DomainStatus[0]);
 
-            Assert.AreEqual(13, response.FieldsParsed);
+            Assert.AreEqual(14, response.FieldsParsed);
         }
 
         [Test]

--- a/Whois.Tests/Parsing/whois.eu/eu/EuParsingTests.cs
+++ b/Whois.Tests/Parsing/whois.eu/eu/EuParsingTests.cs
@@ -33,6 +33,7 @@ namespace Whois.Parsing.Whois.Eu.Eu
 
             // Registrar Details
             Assert.AreEqual("EURid vzw/asbl", response.Registrar.Name);
+            Assert.AreEqual("www.eurid.eu", response.Registrar.Url);
 
             // Nameservers
             Assert.AreEqual(5, response.NameServers.Count);
@@ -42,7 +43,7 @@ namespace Whois.Parsing.Whois.Eu.Eu
             Assert.AreEqual("ns1.eurid.eu", response.NameServers[3]);
             Assert.AreEqual("ns2.eurid.eu", response.NameServers[4]);
 
-            Assert.AreEqual(8, response.FieldsParsed);
+            Assert.AreEqual(9, response.FieldsParsed);
         }
 
         [Test]

--- a/Whois.Tests/Parsing/whois.isoc.org.il/il/IlParsingTests.cs
+++ b/Whois.Tests/Parsing/whois.isoc.org.il/il/IlParsingTests.cs
@@ -48,6 +48,7 @@ namespace Whois.Parsing.Whois.Isoc.Org.Il.Il
 
             // Registrar Details
             Assert.AreEqual("Israel Internet Association ISOC-IL", response.Registrar.Name);
+            Assert.AreEqual("www.isoc.org.il", response.Registrar.Url);
 
             Assert.AreEqual(new DateTime(2005, 01, 26, 00, 00, 00, 000, DateTimeKind.Utc), response.Updated);
             Assert.AreEqual(new DateTime(2001, 08, 21, 00, 00, 00, 000, DateTimeKind.Utc), response.Registered);
@@ -118,7 +119,7 @@ namespace Whois.Parsing.Whois.Isoc.Org.Il.Il
             Assert.AreEqual(1, response.DomainStatus.Count);
             Assert.AreEqual("Transfer Allowed", response.DomainStatus[0]);
 
-            Assert.AreEqual(27, response.FieldsParsed);
+            Assert.AreEqual(28, response.FieldsParsed);
         }
 
         [Test]
@@ -137,6 +138,7 @@ namespace Whois.Parsing.Whois.Isoc.Org.Il.Il
 
             // Registrar Details
             Assert.AreEqual("Israel Internet Association ISOC-IL", response.Registrar.Name);
+            Assert.AreEqual("www.isoc.org.il", response.Registrar.Url);
 
             Assert.AreEqual(new DateTime(2010, 10, 07, 00, 00, 00, 000, DateTimeKind.Utc), response.Updated);
             Assert.AreEqual(new DateTime(1996, 01, 11, 00, 00, 00, 000, DateTimeKind.Utc), response.Registered);
@@ -216,7 +218,7 @@ namespace Whois.Parsing.Whois.Isoc.Org.Il.Il
             Assert.AreEqual(1, response.DomainStatus.Count);
             Assert.AreEqual("Transfer Locked", response.DomainStatus[0]);
 
-            Assert.AreEqual(56, response.FieldsParsed);
+            Assert.AreEqual(57, response.FieldsParsed);
         }
 
         [Test]
@@ -250,6 +252,7 @@ namespace Whois.Parsing.Whois.Isoc.Org.Il.Il
 
             // Registrar Details
             Assert.AreEqual("Israel Internet Association ISOC-IL", response.Registrar.Name);
+            Assert.AreEqual("www.isoc.org.il", response.Registrar.Url);
 
             Assert.AreEqual(new DateTime(2014, 01, 16, 00, 00, 00, 000, DateTimeKind.Utc), response.Updated);
             Assert.AreEqual(new DateTime(1996, 01, 11, 00, 00, 00, 000, DateTimeKind.Utc), response.Registered);
@@ -329,7 +332,7 @@ namespace Whois.Parsing.Whois.Isoc.Org.Il.Il
             Assert.AreEqual(1, response.DomainStatus.Count);
             Assert.AreEqual("Transfer Locked", response.DomainStatus[0]);
 
-            Assert.AreEqual(48, response.FieldsParsed);
+            Assert.AreEqual(49, response.FieldsParsed);
         }
     }
 }

--- a/Whois.Tests/Parsing/whois.nic.co/co/CoParsingTests.cs
+++ b/Whois.Tests/Parsing/whois.nic.co/co/CoParsingTests.cs
@@ -53,6 +53,7 @@ namespace Whois.Parsing.Whois.Nic.Co.Co
             // Registrar Details
             Assert.AreEqual("CSC CORPORATE DOMAINS", response.Registrar.Name);
             Assert.AreEqual("299", response.Registrar.IanaId);
+            Assert.AreEqual("whois.corporatedomains.com", response.Registrar.Url);
 
             Assert.AreEqual(new DateTime(2013, 10, 14, 13, 03, 24, 000, DateTimeKind.Utc), response.Updated);
             Assert.AreEqual(new DateTime(2010, 04, 26, 07, 50, 40, 000, DateTimeKind.Utc), response.Registered);
@@ -144,7 +145,7 @@ namespace Whois.Parsing.Whois.Nic.Co.Co
             Assert.AreEqual(1, response.DomainStatus.Count);
             Assert.AreEqual("clientTransferProhibited", response.DomainStatus[0]);
 
-            Assert.AreEqual(65, response.FieldsParsed);
+            Assert.AreEqual(66, response.FieldsParsed);
         }
     }
 }

--- a/Whois.Tests/Parsing/whois.nic.dm/dm/DmParsingTests.cs
+++ b/Whois.Tests/Parsing/whois.nic.dm/dm/DmParsingTests.cs
@@ -48,6 +48,7 @@ namespace Whois.Parsing.Whois.Nic.Dm.Dm
 
             // Registrar Details
             Assert.AreEqual("MarkMonitor Inc.", response.Registrar.Name);
+            Assert.AreEqual("www.markmonitor.com", response.Registrar.Url);
 
             Assert.AreEqual(new DateTime(2013, 07, 23, 17, 50, 34, 000, DateTimeKind.Utc), response.Updated);
             Assert.AreEqual(new DateTime(2004, 08, 23, 23, 00, 00, 000, DateTimeKind.Utc), response.Registered);
@@ -115,7 +116,7 @@ namespace Whois.Parsing.Whois.Nic.Dm.Dm
             Assert.AreEqual(1, response.DomainStatus.Count);
             Assert.AreEqual("ACTIVE", response.DomainStatus[0]);
 
-            Assert.AreEqual(38, response.FieldsParsed);
+            Assert.AreEqual(39, response.FieldsParsed);
         }
     }
 }

--- a/Whois.Tests/Parsing/whois.nic.ec/ex/ExParsingTests.cs
+++ b/Whois.Tests/Parsing/whois.nic.ec/ex/ExParsingTests.cs
@@ -51,12 +51,13 @@ namespace Whois.Parsing.Whois.Nic.Ec.Ex
 
             // Registrar Details
             Assert.AreEqual("MarkMonitor Inc.", response.Registrar.Name);
+            Assert.AreEqual("www.markmonitor.com", response.Registrar.Url);
 
             Assert.AreEqual(new DateTime(2013, 09, 17, 00, 00, 00, 000, DateTimeKind.Utc), response.Updated);
             Assert.AreEqual(new DateTime(2003, 10, 16, 00, 00, 00, 000, DateTimeKind.Utc), response.Registered);
             Assert.AreEqual(new DateTime(2014, 10, 16, 00, 00, 00, 000, DateTimeKind.Utc), response.Expiration);
 
-             // Registrant Details
+            // Registrant Details
             Assert.AreEqual("Rose Hagan", response.Registrant.Name);
             Assert.AreEqual("Google Inc.", response.Registrant.Organization);
             Assert.AreEqual("1-6503300100", response.Registrant.TelephoneNumber);
@@ -90,7 +91,7 @@ namespace Whois.Parsing.Whois.Nic.Ec.Ex
             Assert.AreEqual("ns3.google.com", response.NameServers[2]);
             Assert.AreEqual("ns4.google.com", response.NameServers[3]);
 
-            Assert.AreEqual(26, response.FieldsParsed);
+            Assert.AreEqual(27, response.FieldsParsed);
         }
     }
 }

--- a/Whois.Tests/Parsing/whois.nic.gd/gd/GdParsingTests.cs
+++ b/Whois.Tests/Parsing/whois.nic.gd/gd/GdParsingTests.cs
@@ -48,6 +48,7 @@ namespace Whois.Parsing.Whois.Nic.Gd.Gd
 
             // Registrar Details
             Assert.AreEqual("MarkMonitor Inc.", response.Registrar.Name);
+            Assert.AreEqual("www.markmonitor.com", response.Registrar.Url);
 
             Assert.AreEqual(new DateTime(2013, 11, 12, 16, 07, 05, 000, DateTimeKind.Utc), response.Updated);
             Assert.AreEqual(new DateTime(2006, 12, 11, 00, 00, 00, 000, DateTimeKind.Utc), response.Registered);
@@ -124,7 +125,7 @@ namespace Whois.Parsing.Whois.Nic.Gd.Gd
             Assert.AreEqual("clientupdateprohibited", response.DomainStatus[0]);
             Assert.AreEqual("clienttransferprohibited", response.DomainStatus[1]);
 
-            Assert.AreEqual(49, response.FieldsParsed);
+            Assert.AreEqual(50, response.FieldsParsed);
         }
 
         [Test]

--- a/Whois.Tests/Parsing/whois.nic.st/st/StParsingTests.cs
+++ b/Whois.Tests/Parsing/whois.nic.st/st/StParsingTests.cs
@@ -50,6 +50,7 @@ namespace Whois.Parsing.Whois.Nic.St.St
 
             // Registrar Details
             Assert.AreEqual("MarkMonitor Inc.", response.Registrar.Name);
+            Assert.AreEqual("www.markmonitor.com", response.Registrar.Url);
 
             Assert.AreEqual(new DateTime(2017, 05, 14, 09, 28, 07, 000, DateTimeKind.Utc), response.Updated);
             Assert.AreEqual(new DateTime(2004, 06, 15, 18, 24, 45, 000, DateTimeKind.Utc), response.Registered);
@@ -127,7 +128,7 @@ namespace Whois.Parsing.Whois.Nic.St.St
             Assert.AreEqual(1, response.DomainStatus.Count);
             Assert.AreEqual("clientUpdateProhibited", response.DomainStatus[0]);
 
-            Assert.AreEqual(53, response.FieldsParsed);
+            Assert.AreEqual(54, response.FieldsParsed);
         }
     }
 }

--- a/Whois.Tests/Parsing/whois.nic.tel/tel/TelParsingTests.cs
+++ b/Whois.Tests/Parsing/whois.nic.tel/tel/TelParsingTests.cs
@@ -51,6 +51,7 @@ namespace Whois.Parsing.Whois.Nic.Tel.Tel
 
             // Registrar Details
             Assert.AreEqual("292", response.Registrar.IanaId);
+            Assert.AreEqual("www.markmonitor.com", response.Registrar.Url);
 
             Assert.AreEqual(new DateTime(2014, 03, 22, 23, 59, 59, 000, DateTimeKind.Utc), response.Updated);
             Assert.AreEqual(new DateTime(2009, 03, 23, 23, 59, 59, 000, DateTimeKind.Utc), response.Registered);
@@ -143,7 +144,7 @@ namespace Whois.Parsing.Whois.Nic.Tel.Tel
             Assert.AreEqual("clientTransferProhibited", response.DomainStatus[1]);
             Assert.AreEqual("clientUpdateProhibited", response.DomainStatus[2]);
 
-            Assert.AreEqual(64, response.FieldsParsed);
+            Assert.AreEqual(65, response.FieldsParsed);
         }
     }
 }

--- a/Whois.Tests/Parsing/whois.nic.travel/travel/TravelParsingTests.cs
+++ b/Whois.Tests/Parsing/whois.nic.travel/travel/TravelParsingTests.cs
@@ -253,6 +253,9 @@ namespace Whois.Parsing.Whois.Nic.Travel.Travel
             Assert.AreEqual(new DateTime(2005, 10, 04, 21, 44, 27, 000, DateTimeKind.Utc), response.Registered);
             Assert.AreEqual(new DateTime(2013, 09, 18, 15, 13, 32, 000, DateTimeKind.Utc), response.Expiration);
 
+             // Registrar Details
+            Assert.AreEqual("whois.neustar.us", response.Registrar.Url);
+
              // Registrant Details
             Assert.AreEqual("TRALLIANCE", response.Registrant.RegistryId);
             Assert.AreEqual("Tralliance Corporation", response.Registrant.Name);
@@ -326,7 +329,7 @@ namespace Whois.Parsing.Whois.Nic.Travel.Travel
             Assert.AreEqual(1, response.DomainStatus.Count);
             Assert.AreEqual("ok", response.DomainStatus[0]);
 
-            Assert.AreEqual(49, response.FieldsParsed);
+            Assert.AreEqual(50, response.FieldsParsed);
         }
     }
 }

--- a/Whois.Tests/Parsing/whois.nic.us/us/UsParsingTests.cs
+++ b/Whois.Tests/Parsing/whois.nic.us/us/UsParsingTests.cs
@@ -51,6 +51,7 @@ namespace Whois.Parsing.Whois.Nic.Us.Us
 
             // Registrar Details
             Assert.AreEqual("292", response.Registrar.IanaId);
+            Assert.AreEqual("whois.markmonitor.com", response.Registrar.Url);
 
             Assert.AreEqual(new DateTime(2014, 04, 18, 23, 59, 59, 000, DateTimeKind.Utc), response.Updated);
             Assert.AreEqual(new DateTime(2002, 04, 19, 23, 15, 57, 000, DateTimeKind.Utc), response.Registered);
@@ -141,7 +142,7 @@ namespace Whois.Parsing.Whois.Nic.Us.Us
             Assert.AreEqual("clientTransferProhibited", response.DomainStatus[1]);
             Assert.AreEqual("clientUpdateProhibited", response.DomainStatus[2]);
 
-            Assert.AreEqual(62, response.FieldsParsed);
+            Assert.AreEqual(63, response.FieldsParsed);
         }
     }
 }

--- a/Whois/Resources/generic/tld/Found01.txt
+++ b/Whois/Resources/generic/tld/Found01.txt
@@ -121,7 +121,7 @@ Registrar:{ Registrar.Name : Trim }
 Registrar IANA ID:{ Registrar.IanaId : Trim, IsNumeric }
 Registrar Abuse Contact Email:{ Registrar.AbuseEmail : Trim, IsEmail }
 Registrar Abuse Contact Phone:{ Registrar.AbuseTelephoneNumber : Trim, IsPhoneNumber }
-Registrar URL:{ Registrar.Url : Trim, IsUrl, ToLower } 
+Registrar URL:{ Registrar.Url : Trim, IsLooseAbsoluteUrl, ToLower } 
 Registrar WHOIS Server:{ Registrar.WhoisServer : Trim, RemoveEnd('/'), IsDomainName, ToHostName }
 
 #
@@ -129,13 +129,13 @@ Registrar WHOIS Server:{ Registrar.WhoisServer : Trim, RemoveEnd('/'), IsDomainN
 #
 Sponsoring Registrar:{ Registrar.Name : Trim }
 Sponsoring Registrar IANA ID:{ Registrar.IanaId : Trim, IsNumeric }
-Sponsoring Registrar URL:{ Registrar.Url : Trim, IsUrl, ToLower }
+Sponsoring Registrar URL:{ Registrar.Url : Trim, IsLooseAbsoluteUrl, ToLower }
 Sponsoring Registrar Phone:{ Registrar.AbuseTelephoneNumber : Trim, IsPhoneNumber }
 Sponsoring Registrar Customer Service Contact:{ Registrar.AbuseTelephoneNumber : Trim, IsPhoneNumber }
 Sponsoring Registrar Customer Service Email:{ Registrar.AbuseEmail : Trim, IsEmail }
 
 # Alternate form
-Referral URL:{ Registrar.Url : Trim, IsUrl, ToLower } 
+Referral URL:{ Registrar.Url : Trim, IsLooseAbsoluteUrl, ToLower } 
 
 #
 # Domain Status

--- a/Whois/Resources/generic/tld/Found02.txt
+++ b/Whois/Resources/generic/tld/Found02.txt
@@ -22,7 +22,7 @@ set: Status = Found
    Domain Name: { DomainName : Trim, IsDomainName, ToHostName }
    Registry Domain ID: { RegistryDomainId ? : Trim }
    Registrar WHOIS Server: { Registrar.WhoisServer ? : IsNotEmpty, Trim, IsDomainName, ToHostName }
-   Registrar URL: { Registrar.Url ? : Trim, IsUrl, ToLower }
+   Registrar URL: { Registrar.Url ? : Trim, IsLooseAbsoluteUrl, ToLower }
    Updated Date: { Updated ? : Trim, ToDateTimeUtc("yyyy-MM-ddTHH:mm:ssZ") }
    Updated Date: { Updated ? : Trim, ToDateTimeUtc("dd-MMM-yyyy") }
    Creation Date: { Registered ? : Trim, ToDateTimeUtc("yyyy-MM-ddTHH:mm:ssZ") }

--- a/Whois/Resources/tvwhois.verisign-grs.com/tv/Found.txt
+++ b/Whois/Resources/tvwhois.verisign-grs.com/tv/Found.txt
@@ -14,7 +14,7 @@ set: Status = Found
    Domain Name: { DomainName : IsDomainName, ToHostName, EOL }
    Registry Domain ID: { RegistryDomainId ? : IsNumeric, EOL }
    Registrar WHOIS Server: { Registrar.WhoisServer ? : IsDomainName, ToHostName, EOL }
-   Registrar URL: { Registrar.Url ? : IsUrl, ToLower, EOL }
+   Registrar URL: { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower, EOL }
    Updated Date: { Updated ? : ToDateTimeUtc("yyyy-MM-ddTHH:mm:ssZ"), EOL }
    Creation Date: { Registered ? : ToDateTimeUtc("yyyy-MM-ddTHH:mm:ssZ"), EOL }
    Registry Expiry Date: { Expiration ? : ToDateTimeUtc("yyyy-MM-ddTHH:mm:ssZ"), EOL }

--- a/Whois/Resources/tvwhois.verisign-grs.com/tv/FoundV1.txt
+++ b/Whois/Resources/tvwhois.verisign-grs.com/tv/FoundV1.txt
@@ -15,7 +15,7 @@ set: Status = Found
    Domain Name: { DomainName : IsDomainName, ToHostName, EOL }
    Registrar: { Registrar.Name ? : EOL }
    Whois Server: { Registrar.WhoisServer ?: IsDomainName, ToHostName, EOL }
-   Referral URL: { Registrar.Url ? : IsUrl, ToLower, EOL }
+   Referral URL: { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower, EOL }
    Name Server: { NameServers ? : IsDomainName, Repeating, EOL }
    Status: { DomainStatus ? : Repeating, SubstringBefore(' '), EOL }
    Updated Date: { Updated ? : ToDateTime("dd-MMM-yyyy"), EOL }

--- a/Whois/Resources/whois.cat/cat/Found.txt
+++ b/Whois/Resources/whois.cat/cat/Found.txt
@@ -26,8 +26,8 @@ Registrar IANA ID:{ Registrar.IanaId ? : Trim, IsNumeric, EOL }
 Sponsoring Registrar:{ Registrar.Name ? : Trim, EOL }
 Sponsoring Registrar IANA ID:{ Registrar.IanaId ? : Trim, IsNumeric, EOL }
 WHOIS Server:{ Registrar.WhoisServer ? : Trim, IsDomainName, ToHostName, EOL } 
-Referral URL:{ Registrar.Url ? : Trim, IsUrl, ToLower, EOL } 
-Registrar URL:{ Registrar.Url ? : Trim, IsUrl, ToLower, EOL } 
+Referral URL:{ Registrar.Url ? : Trim, IsLooseAbsoluteUrl, ToLower, EOL } 
+Registrar URL:{ Registrar.Url ? : Trim, IsLooseAbsoluteUrl, ToLower, EOL } 
 Domain Status:{ DomainStatus ? : Trim, Repeating, SubstringBefore(' '), EOL }
 Status:{ DomainStatus ? : Trim, Repeating, EOL }
 Registrant ID:{ Registrant.RegistryId ? : Trim, EOL }

--- a/Whois/Resources/whois.cctld.uz/uz/Found.txt
+++ b/Whois/Resources/whois.cctld.uz/uz/Found.txt
@@ -17,7 +17,7 @@ hint: Contact
    Domain Name: { DomainName : IsDomainName, ToHostName, EOL }
    Registrar: { Registrar.Name ? : EOL }
    Whois Server: { Registrar.WhoisServer ? : IsDomainName, ToHostName, EOL }
-   Referral URL: { Registrar.Url ? : IsUrl, ToLower, EOL }
+   Referral URL: { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower, EOL }
    Name Server: { NameServers ? : SubstringBefore(". "), IsDomainName, ToLower, Repeating, EOL }
    Status: { DomainStatus ? : Trim, Repeating, EOL }
    Updated Date: { Updated ? : ToDateTime("dd-MMM-yyyy"), EOL }

--- a/Whois/Resources/whois.cctld.uz/uz/Reserved.txt
+++ b/Whois/Resources/whois.cctld.uz/uz/Reserved.txt
@@ -18,7 +18,7 @@ hint: RESERVED
    Domain Name: { DomainName : IsDomainName, ToHostName, EOL }
    Registrar: { Registrar.Name ? : EOL }
    Whois Server: { Registrar.WhoisServer ? : IsDomainName, ToHostName, EOL }
-   Referral URL: { Registrar.Url ? : IsUrl, ToLower, EOL }
+   Referral URL: { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower, EOL }
    Name Server: { NameServers ? : SubstringBefore(". "), IsDomainName, ToLower, Repeating, EOL }
    Status: { DomainStatus ? : Trim, Repeating, EOL }
    Updated Date: { Updated ? : ToDateTime("dd-MMM-yyyy"), EOL }

--- a/Whois/Resources/whois.centralnic.com/Found.txt
+++ b/Whois/Resources/whois.centralnic.com/Found.txt
@@ -130,4 +130,4 @@ Billing Email:{ BillingContact.Email ? : IsEmail, EOL }
 Sponsoring Registrar IANA ID:{ Registrar.IanaId ? : IsNumeric, EOL }
 Sponsoring Registrar Organization:{ Registrar.Name ? : EOL }
 Sponsoring Registrar Phone:{ Registrar.AbuseTelephoneNumber ? : IsPhoneNumber, EOL }
-Sponsoring Registrar Website:{ Registrar.Url ? : IsUrl, ToLower, EOL }
+Sponsoring Registrar Website:{ Registrar.Url ? : IsLooseAbsoluteUrl, ToLower, EOL }

--- a/Whois/Resources/whois.cmc.iq/iq/Found.txt
+++ b/Whois/Resources/whois.cmc.iq/iq/Found.txt
@@ -14,7 +14,7 @@ set: Status = Found
 Domain Name: { DomainName : IsDomainName, ToHostName, EOL }
 Domain ID: { RegistryDomainId ? : EOL }
 WHOIS Server: { Registrar.WhoisServer ? : IsDomainName, ToHostName, EOL }
-Referral URL: { Registrar.Url ? : IsUrl, ToLower, EOL }
+Referral URL: { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower, EOL }
 Updated Date: { Updated ? : ToDateTimeUtc("yyyy-MM-ddTHH:mm:ss.fffZ"), EOL }
 Creation Date: { Registered? : ToDateTimeUtc("yyyy-MM-ddTHH:mm:ss.fffZ"), EOL }
 Registry Expiry Date: { Expiration ? : ToDateTimeUtc("yyyy-MM-ddTHH:mm:ss.fffZ"), EOL }

--- a/Whois/Resources/whois.dns.be/be/Found.txt
+++ b/Whois/Resources/whois.dns.be/be/Found.txt
@@ -30,7 +30,7 @@ Registrar Technical Contacts:
 
 Registrar:
 	Name:	 { Registrar.Name ? : Trim, EOL }
-	Website: { Registrar.Url ? : Trim, IsUrl, ToLower, EOL }
+	Website: { Registrar.Url ? : Trim, IsLooseAbsoluteUrl, ToLower, EOL }
 
 Nameservers:
 	{ NameServers : Trim, IsDomainName, ToLower, Repeating, EOL }

--- a/Whois/Resources/whois.dns.be/be/OutOfService.txt
+++ b/Whois/Resources/whois.dns.be/be/OutOfService.txt
@@ -33,7 +33,7 @@ Registrar Technical Contacts:
 
 Registrar:
 	Name:	 { Registrar.Name ? : Trim, EOL }
-	Website: { Registrar.Url ? : Trim, IsUrl, ToLower, EOL }
+	Website: { Registrar.Url ? : Trim, IsLooseAbsoluteUrl, ToLower, EOL }
 
 Nameservers:
 	{ NameServers : Trim, IsDomainName, ToLower, Repeating, EOL }

--- a/Whois/Resources/whois.dns.lu/lu/Found.txt
+++ b/Whois/Resources/whois.dns.lu/lu/Found.txt
@@ -38,5 +38,5 @@ tec-city:{ TechnicalContact.Address ? : Trim, IsNotEmpty }
 tec-country:{ TechnicalContact.Address ? : Trim, IsNotEmpty }
 tec-email:{ TechnicalContact.Email ? : Trim, IsEmail }
 registrar-name:{ Registrar.Name ? : Trim }
-registrar-url:{ Registrar.Url ? : Trim, IsUrl, ToLower }
+registrar-url:{ Registrar.Url ? : Trim, IsLooseAbsoluteUrl, ToLower }
 

--- a/Whois/Resources/whois.domreg.lt/lt/Found.txt
+++ b/Whois/Resources/whois.domreg.lt/lt/Found.txt
@@ -18,7 +18,7 @@ Domain:			{ DomainName : Trim, IsDomainName, ToHostName }
 Status:			{ DomainStatus ? : Trim, Repeating }
 Registered:		{ Registered? : ToDateTimeUtc("yyyy-MM-dd") }
 Registrar:		{ Registrar.Name ? : Trim }
-Registrar website:	{ Registrar.Url ? : Trim, IsUrl, ToLower }
+Registrar website:	{ Registrar.Url ? : Trim, IsLooseAbsoluteUrl, ToLower }
 Contact organization:	{ Registrant.Organization ? : Trim }
 Contact email:		{ Registrant.Email ? : Trim, IsEmail }
 Nameserver:		{ NameServers ? : SubstringBefore(' '), IsDomainName, ToLower, Repeating }

--- a/Whois/Resources/whois.eu/eu/Found.txt
+++ b/Whois/Resources/whois.eu/eu/Found.txt
@@ -18,7 +18,7 @@ Domain: { DomainName : IsDomainName, ToHostName }
 
 Registrar:
 	Name:	 { Registrar.Name ? }
-	Website: { Registrar.Url ? : IsUrl, ToLower }
+	Website: { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }
 
 Name servers:
 	{ NameServers ? : SubstringBefore(' '), IsDomainName, ToLower, Repeating }

--- a/Whois/Resources/whois.isoc.org.il/il/Found.txt
+++ b/Whois/Resources/whois.isoc.org.il/il/Found.txt
@@ -43,4 +43,4 @@ fax-no:       { Fax : IsPhoneNumber, Repeating }
 e-mail:       { Email : Replace(' AT ', '@'), IsEmail, Repeating }
 
 registrar name: { Registrar.Name ? }
-registrar info: { Registrar.Url ? : IsUrl, ToLower }
+registrar info: { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }

--- a/Whois/Resources/whois.je/je/Found.txt
+++ b/Whois/Resources/whois.je/je/Found.txt
@@ -23,7 +23,7 @@ Name Servers:
 
 Registrar Information
 Registrar Name: { Registrar.Name ? }
-Registration URL: { Registrar.Url ? : IsUrl, ToLower }
+Registration URL: { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }
 
 Registrant:
 Name: { Registrant.Name ? }

--- a/Whois/Resources/whois.monic.mo/mo/Found.txt
+++ b/Whois/Resources/whois.monic.mo/mo/Found.txt
@@ -17,5 +17,5 @@ set: Status = Found
    Domain Name: { DomainName : IsDomainName, ToHostName }
    Registrar: { Registrar.Name ? }
    Whois Server: { Registrar.WhoisServer ? : IsDomainName, ToHostName }
-   Referral URL: { Registrar.Url ? : IsUrl, ToLower }
+   Referral URL: { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }
    Name Server: { NameServers ? : IsDomainName, ToLower, Repeating }

--- a/Whois/Resources/whois.nic.co/co/Found.txt
+++ b/Whois/Resources/whois.nic.co/co/Found.txt
@@ -18,7 +18,7 @@ Domain Name:                                 { DomainName : IsDomainName, ToHost
 Domain ID:                                   { RegistryDomainId ? }
 Sponsoring Registrar:                        { Registrar.Name ? }
 Sponsoring Registrar IANA ID:                { Registrar.IanaId ? : IsNumeric }
-Registrar URL (registration services):       { Registrar.Url ? : IsUrl, ToLower }
+Registrar URL (registration services):       { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }
 Domain Status:                               { DomainStatus ? : Repeating, CleanDomainStatus }
 Registrant ID:                               { Registrant.RegistryId ? }
 Registrant Name:                             { Registrant.Name ? }

--- a/Whois/Resources/whois.nic.dm/dm/Found.txt
+++ b/Whois/Resources/whois.nic.dm/dm/Found.txt
@@ -16,7 +16,7 @@ set: Status = Found
 ---
 domain name: { DomainName : IsDomainName, ToHostName }
 registrar: { Registrar.Name ? }
-url: { Registrar.Url ? : IsUrl, ToLower }
+url: { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }
 status: { DomainStatus ? : Repeating, CleanDomainStatus }
 created date: { Registered ? : ToDateTimeUtc("yyyy-MM-dd HH:mm:ss") }
 updated date: { Updated ? : ToDateTimeUtc("yyyy-MM-dd HH:mm:ss") }

--- a/Whois/Resources/whois.nic.ec/ex/Found.txt
+++ b/Whois/Resources/whois.nic.ec/ex/Found.txt
@@ -24,7 +24,7 @@ Name Servers:
 
 Registrar Information
 Registrar Name: { Registrar.Name ? }
-Registration URL: { Registrar.Url ? : IsUrl, ToLower }
+Registration URL: { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }
 
 Registrant:
 Name: { Registrant.Name ? }

--- a/Whois/Resources/whois.nic.gd/gd/Found.txt
+++ b/Whois/Resources/whois.nic.gd/gd/Found.txt
@@ -19,7 +19,7 @@ set: Status = Found
 ---
 domain name: { DomainName : IsDomainName, ToHostName }
 registrar: { Registrar.Name ? }
-url: { Registrar.Url ? : IsUrl, ToLower }
+url: { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }
 status: { DomainStatus ? : Repeating, CleanDomainStatus }
 status: { DomainStatus ? : Repeating, CleanDomainStatus }
 created date: { Registered ? : ToDateTimeUtc("yyyy-MM-dd HH:mm:ss") }

--- a/Whois/Resources/whois.nic.jobs/jobs/Found.txt
+++ b/Whois/Resources/whois.nic.jobs/jobs/Found.txt
@@ -20,7 +20,7 @@ set: Status = Found
    Domain Name: { DomainName : IsDomainName, ToHostName }
    Registry Domain ID: { RegistryDomainId ? }
    Registrar WHOIS Server: { Registrar.WhoisServer ? : IsDomainName, ToHostName }
-   Registrar URL: { Registrar.Url ? : IsUrl, ToLower }
+   Registrar URL: { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }
    Updated Date: { Updated ? : ToDateTimeUtc("yyyy-MM-ddTHH:mm:ssZ") }
    Creation Date: { Registered ? : ToDateTimeUtc("yyyy-MM-ddTHH:mm:ssZ") }
    Registry Expiry Date: { Expiration ? : ToDateTimeUtc("yyyy-MM-ddTHH:mm:ssZ") }

--- a/Whois/Resources/whois.nic.mx/mx/Found.txt
+++ b/Whois/Resources/whois.nic.mx/mx/Found.txt
@@ -23,7 +23,7 @@ Created On: { Registered ? : Trim, ToDateTimeUtc("yyyy-MM-dd") }
 Expiration Date: { Expiration ? : Trim, ToDateTimeUtc("yyyy-MM-dd") }
 Last Updated On: { Updated ? : Trim, ToDateTimeUtc("yyyy-MM-dd") }
 Registrar: { Registrar.Name ? : Trim }
-URL: { Registrar.Url ? : Trim, IsUrl, ToLower }
+URL: { Registrar.Url ? : Trim, IsLooseAbsoluteUrl, ToLower }
 
 Registrant:
    Name: { Registrant.Name ? : Trim }

--- a/Whois/Resources/whois.nic.st/st/Found.txt
+++ b/Whois/Resources/whois.nic.st/st/Found.txt
@@ -25,7 +25,7 @@ Expiration Date: { Expiration ? : ToDateTimeUtc("yyyy-MM-dd") }
 DOMAIN: { DomainName : IsDomainName, ToHostName }
 
 REGISTRATION-SERVICE-PROVIDER: { Registrar.Name ? }
-URL: { Registrar.Url ? : IsUrl, ToLower }
+URL: { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }
 
 created-date:    { Registered ? : ToDateTimeUtc("yyyy-MM-dd HH:mm:ss") }
 updated-date:    { Updated ? : ToDateTimeUtc("yyyy-MM-dd HH:mm:ss") }

--- a/Whois/Resources/whois.nic.tel/tel/Found.txt
+++ b/Whois/Resources/whois.nic.tel/tel/Found.txt
@@ -18,7 +18,7 @@ Domain Name:                                 { DomainName : IsDomainName, ToHost
 Domain ID:                                   { RegistryDomainId ? }
 dponsoring Registrar:                        { Registrar.Name ? }
 Sponsoring Registrar IANA ID:                { Registrar.IanaId ? : IsNumeric }
-Registrar URL (registration services):       { Registrar.Url ? : IsUrl, ToLower }
+Registrar URL (registration services):       { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }
 Domain Status:                               { DomainStatus ? : Repeating, CleanDomainStatus }
 Registrant ID:                               { Registrant.RegistryId ? }
 Registrant Name:                             { Registrant.Name ? }

--- a/Whois/Resources/whois.nic.travel/travel/Found.txt
+++ b/Whois/Resources/whois.nic.travel/travel/Found.txt
@@ -18,7 +18,7 @@ Domain Name:                                 { DomainName : IsDomainName, ToHost
 Domain ID:                                   { RegistryDomainId ? }
 dponsoring Registrar:                        { Registrar.Name ? }
 Sponsoring Registrar IANA ID:                { Registrar.IanaId ? : IsNumeric }
-Registrar URL (registration services):       { Registrar.Url ? : IsUrl, ToLower }
+Registrar URL (registration services):       { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }
 Domain Status:                               { DomainStatus ? : Repeating, CleanDomainStatus }
 Registrant ID:                               { Registrant.RegistryId ? }
 Registrant Name:                             { Registrant.Name ? }

--- a/Whois/Resources/whois.nic.uk/uk/Found.txt
+++ b/Whois/Resources/whois.nic.uk/uk/Found.txt
@@ -26,7 +26,7 @@ set: Status = Found
 
     Registrar:
         { Registrar.Name }
-        URL: { Registrar.Url ? : IsUrl, ToLower }
+        URL: { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }
 
     Relevant dates:
         Registered on: { Registered ? : Trim, Replace('before ', '01-'), ToDateTimeUtc("dd-MMM-yyyy") }

--- a/Whois/Resources/whois.nic.us/us/Found.txt
+++ b/Whois/Resources/whois.nic.us/us/Found.txt
@@ -18,7 +18,7 @@ Domain Name:                                 { DomainName : IsDomainName, ToHost
 Domain ID:                                   { RegistryDomainId ? }
 dponsoring Registrar:                        { Registrar.Name ? }
 Sponsoring Registrar IANA ID:                { Registrar.IanaId ? : IsNumeric }
-Registrar URL (registration services):       { Registrar.Url ? : IsUrl, ToLower }
+Registrar URL (registration services):       { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }
 Domain Status:                               { DomainStatus ? : Repeating, CleanDomainStatus }
 Registrant ID:                               { Registrant.RegistryId ? }
 Registrant Name:                             { Registrant.Name ? }

--- a/Whois/Resources/whois.register.si/si/Found.txt
+++ b/Whois/Resources/whois.register.si/si/Found.txt
@@ -16,7 +16,7 @@ set: Status = Found
 ---
 domain:		{ DomainName : IsDomainName, ToHostName }
 registrar:	{ Registrar.Name ? }
-registrar-url:	{ Registrar.Url ? : IsUrl, ToLower }
+registrar-url:	{ Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }
 nameserver:	{ NameServers ? : IsDomainName, ToLower, Repeating }
 registrant:	{ Registrant.RegistryId ? }
 status:		{ DomainStatus ? : Split(', ') }

--- a/Whois/Resources/whois.registry.hm/hm/Found.txt
+++ b/Whois/Resources/whois.registry.hm/hm/Found.txt
@@ -13,7 +13,7 @@ set: Status = Found
 ---
    Domain name:  { DomainName : IsDomainName, ToHostName, EOL }
    Registrar:    { Registrar.Name ? : EOL }
-   Referral URL: { Registrar.Url ? : IsUrl, ToLower, EOL }
+   Referral URL: { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower, EOL }
 
    Domain Registrant:
       { Registrant.Name : EOL }

--- a/Whois/Resources/whois.rotld.ro/ro/Found.txt
+++ b/Whois/Resources/whois.rotld.ro/ro/Found.txt
@@ -17,7 +17,7 @@ set: Status = Found
   Domain Name: { DomainName : IsDomainName, ToHostName }
   Registered On: { Registered ? : ToDateTimeUtc("yyyy-MM-dd") }
   Registrar: { Registrar.Name ? }
-  Referral URL: { Registrar.Url ? : IsUrl, ToLower }
+  Referral URL: { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }
 
   Nameserver: { NameServers ? : IsDomainName, ToLower, Repeating }
 

--- a/Whois/Resources/whois.tld.ee/ee/Found.txt
+++ b/Whois/Resources/whois.tld.ee/ee/Found.txt
@@ -39,7 +39,7 @@ changed:    { TechnicalContact.Updated ? : ToDateTimeUtc("yyyy-MM-dd HH:mm:ss zz
 
 Registrar:
 name:       { Registrar.Name ? }
-url:        { Registrar.Url ? : IsUrl, ToLower }
+url:        { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }
 phone:      { Registrar.AbuseTelephoneNumber ? : IsPhoneNumber }
 
 Name servers:

--- a/Whois/Resources/whois.ua/ua/Found01.txt
+++ b/Whois/Resources/whois.ua/ua/Found01.txt
@@ -37,7 +37,7 @@ modified:         { Updated ? : ToDateTimeUtc("yyyy-MM-dd HH:mm:ssz") }
 expires:          { Expiration ? : ToDateTimeUtc("yyyy-MM-dd HH:mm:sszz") }
 
 registrar:        { Registrar.Name ? }
-url:              { Registrar.Url ? : IsUrl, ToLower }
+url:              { Registrar.Url ? : IsLooseAbsoluteUrl, ToLower }
 
 contact-id:       { Contact.Id : Repeating }
 person:           { Contact.Name : Repeating }


### PR DESCRIPTION
The tokenizer library has been updated with loose URL tokenizer support.  This PR switches registrar URL processing to work off of the loose URL validator and updates unit tests for the samples that now have Registrar URLs recognized that were not previously recognizable.